### PR TITLE
Display the version of Erubis at the debug level

### DIFF
--- a/lib/erubis/helpers/rails_helper.rb
+++ b/lib/erubis/helpers/rails_helper.rb
@@ -349,5 +349,5 @@ end   ###
 
 
 ## finish
-ActionController::Base.new.logger.info "** Erubis #{::Erubis::VERSION}"
+ActionController::Base.new.logger.debug "** Erubis #{::Erubis::VERSION}"
 $stdout.puts "** Erubis #{::Erubis::VERSION}" if rails22


### PR DESCRIPTION
Positive effect is to not display it for the production environment.

The side effect of the current implementation is that all of our rake tasks run by cron, that were initially silent when successful, are now displaying the version of Erubis no matter what forcing cron to send out notifications every single time a rake task is run.

Do you think we can sort something out to work around this?

Many thanks for your work on that gem though :)

Gregory

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/kwatch/erubis/1)

<!-- Reviewable:end -->
