### PR TITLE
Fix erubis for modern versions of rubinius

### DIFF
--- a/lib/erubis/main.rb
+++ b/lib/erubis/main.rb
@@ -487,12 +487,12 @@ module Erubis
 
     if defined?(RUBY_ENGINE) && RUBY_ENGINE == "rbx"
       def check_syntax(filename, src)
-        require 'compiler'
+        require 'rubinius/compiler'
         verbose = $VERBOSE
         msg = nil
         begin
           $VERBOSE = true
-          Rubinius::Compiler.compile_string(src, filename)
+          Rubinius::ToolSet.current::TS::Compiler.compile_string(src, filename)
         rescue SyntaxError => ex
           ex_linenum = ex.line
           linenum = 0


### PR DESCRIPTION
The rubinius compiler is now part of the gem rubinius-compiler which has
to be installed separately.
