### PR TITLE
Fix tests for ruby 2.3

### DIFF
--- a/test/test-engines.rb
+++ b/test/test-engines.rb
@@ -71,7 +71,8 @@ __END__
 - name:  ruby2_options
   lang:  ruby
   class: Eruby
-  options: { :bufvar: '@_out_buf' }
+  options:
+    :bufvar: '@_out_buf'
   input: |
       <table>
         <% for item in @items %>
@@ -137,7 +138,9 @@ __END__
 - name:  c1
   lang:  c
   class: Ec
-  options: { :filename: foo.html, :indent: '  ' }
+  options:
+    :filename: foo.html
+    :indent: '  '
   input: |4
       <table>
        <tbody>
@@ -167,7 +170,9 @@ __END__
 - name:  cpp1
   lang:  cpp
   class: Ecpp
-  options: { :filename: foo.html, :indent: '  ' }
+  options:
+    :filename: foo.html
+    :indent: '  '
   input: |4
       <table>
        <tbody>
@@ -197,7 +202,10 @@ __END__
 - name:  java1
   lang:  java
   class: Ejava
-  options: { :buf: _buf, :bufclass: StringBuilder, :indent: '    ' }
+  options:
+    :buf: _buf,
+    :bufclass: StringBuilder
+    :indent: '    '
   input: |
       <table>
        <tbody>
@@ -220,19 +228,19 @@ __END__
   expected: |4
           StringBuilder _buf = new StringBuilder(); _buf.append("<table>\n"
                     + " <tbody>\n");
-           
+      
           int i = 0;
           for (Iterator it = list.iterator(); it.hasNext(); ) {
               String s = (String)it.next();
               i++;
-             
+      
           _buf.append("  <tr class=\""); _buf.append(i%2==0 ? "even" : "odd"); _buf.append("\">\n"
                     + "   <td>"); _buf.append(i); _buf.append("</td>\n"
                     + "   <td>"); _buf.append(escape(s)); _buf.append("</td>\n"
                     + "  </tr>\n");
-           
+      
           }
-          
+      
           _buf.append(" <tbody>\n"
                     + "</table>\n");
            System.err.println("*** debug: i="+(i)); _buf.append("\n");
@@ -242,7 +250,7 @@ __END__
   lang:  scheme
   class: Escheme
   options:
-  input: &scheme1_input|
+  input: &scheme1_input |
       <% (let ((i 0)) %>
       <table>
        <tbody>
@@ -290,7 +298,8 @@ __END__
 - name:  scheme2
   lang:  scheme
   class: Escheme
-  options: { :func: 'display' }
+  options:
+    :func: 'display'
   input: *scheme1_input
   expected: |4
        (let ((i 0)) 
@@ -401,7 +410,8 @@ __END__
 - name:  javascript2
   lang:  javascript
   class: Ejavascript
-  options: { :docwrite: false }
+  options:
+    :docwrite: false
   input: *javascript_input
   expected: |4
       var _buf = [];

--- a/test/test-enhancers.rb
+++ b/test/test-enhancers.rb
@@ -106,13 +106,13 @@ __END__
 ##
 - name:  basic1
   class: Eruby
-  input: &basic1_input|
+  input: &basic1_input |
       <ul>
        <% for item in list %>
         <li><%= item %></li>
        <% end %>
       </ul>
-  src: &basic1_src|
+  src: &basic1_src |
       _buf = ''; _buf << '<ul>
       ';  for item in list 
        _buf << '  <li>'; _buf << ( item ).to_s; _buf << '</li>
@@ -120,7 +120,7 @@ __END__
        _buf << '</ul>
       ';
       _buf.to_s
-  output: &basic1_output|
+  output: &basic1_output |
       <ul>
         <li><aaa></li>
         <li>b&b</li>
@@ -193,7 +193,7 @@ __END__
 ##
 - name:  printenabled1
   class: PrintEnabledEruby
-  input: &printenabled1_input|
+  input: &printenabled1_input |
       <ul>
        <% for item in list %>
         <li><% print item %></li>
@@ -425,7 +425,8 @@ __END__
 ##
 - name:  bipattern2
   class: BiPatternEruby
-  options:  { :bipattern: '\$\{ \}' }
+  options:
+    :bipattern: '\$\{ \}'
   input: |
       <% for item in list %>
         <%=item%> % <%==item%>
@@ -500,7 +501,8 @@ __END__
 ##
 - name:  prefixedline1
   class: PrefixedLineEruby
-  options: { :prefixchar: '!' }
+  options:
+   :prefixchar: '!'
   input: |
       <table>
         ! for item in list

--- a/test/test-erubis.rb
+++ b/test/test-erubis.rb
@@ -220,13 +220,13 @@ y = 20
 
 __END__
 - name:  basic1
-  input: &basic1_input|
+  input: &basic1_input |
       <ul>
        <% for item in list %>
         <li><%= item %></li>
        <% end %>
       </ul>
-  src: &basic1_src|
+  src: &basic1_src |
       _buf = ''; _buf << '<ul>
       ';  for item in list 
        _buf << '  <li>'; _buf << ( item ).to_s; _buf << '</li>
@@ -234,7 +234,7 @@ __END__
        _buf << '</ul>
       ';
       _buf.to_s
-  output: &basic1_output|
+  output: &basic1_output |
       <ul>
         <li><aaa></li>
         <li>b&b</li>
@@ -344,7 +344,7 @@ __END__
 - name:  quotation1
   desc:  single quotation and backslash
   class: Eruby
-  input: &quotation1_input|
+  input: &quotation1_input |
       a = "'"
       b = "\""
       c = '\''
@@ -451,7 +451,9 @@ __END__
 ##
 - name:  bodyonly1
   testopt:  skip_output
-  options: { :preamble: no, :postamble: no }
+  options:
+   :preamble: no
+   :postamble: no
   input: *basic1_input
   src: |4
        _buf << '<ul>
@@ -496,7 +498,7 @@ __END__
 ##
 - name:  nomatch1
   desc:  bug
-  input: &nomatch1|
+  input: &nomatch1 |
       <ul>
         <li>foo</li>
       </ul>
@@ -510,7 +512,8 @@ __END__
 
 ##
 - name:  escape1
-  options: { :escape: true }
+  options:
+   :escape: true
   input: |
       <% str = '<>&"' %>
       <%= str %>
@@ -570,7 +573,7 @@ __END__
 ##
 - name:  optimized1
   class: OptimizedEruby
-  input: &optimized1_input|
+  input: &optimized1_input |
       <table>
        <% for item in list %>
         <tr>
@@ -677,7 +680,7 @@ __END__
 - name:  optimized4
   desc:  single quotation and backslash
   class: OptimizedEruby
-  input: &optimized4_input|
+  input: &optimized4_input |
       a = "'"
       b = "\""
       c = '\''
@@ -751,14 +754,14 @@ __END__
 - name:  pi1
   class:  PI::Eruby
   testopt:  evaluate
-  input: &input_pi1|
+  input: &input_pi1 |
       <ul>
        <?rb for item in @list ?>
         <li>@{item}@ / @!{item}@</li>
         <li><%= item %> / <%== item %></li>
        <?rb end ?>
       </ul>
-  src: &src_pi1|
+  src: &src_pi1 |
       _buf = ''; _buf << '<ul>
       ';  for item in @list 
        _buf << '  <li>'; _buf << Erubis::XmlHelper.escape_xml(item); _buf << ' / '; _buf << (item).to_s; _buf << '</li>
@@ -767,7 +770,7 @@ __END__
        _buf << '</ul>
       ';
       _buf.to_s
-  output: &output_pi1|
+  output: &output_pi1 |
       <ul>
         <li>&lt;aaa&gt; / <aaa></li>
         <li><aaa> / &lt;aaa&gt;</li>
@@ -780,7 +783,8 @@ __END__
 ##
 - name:  pi2
   class:  PI::Eruby
-  options: { :escape: false }
+  options:
+   :escape: false
   testopt:  evaluate
   input: *input_pi1
   src: |
@@ -805,7 +809,9 @@ __END__
 ##
 - name:  pi3
   class:  PI::Eruby
-  options: { :pi: hoge, :embchar: '$' }
+  options:
+   :pi: hoge
+   :embchar: '$'
   testopt:  evaluate
   input: |
       <ul>

--- a/test/test-main.rb
+++ b/test/test-main.rb
@@ -273,7 +273,7 @@ END
       errmsgs << <<'END'
 7: syntax error, unexpected $end, expecting keyword_end
 END
-    elsif ruby20?
+    elsif ruby20? || ruby21?
       errmsgs << <<'END'
 3: syntax error, unexpected ']', expecting ')'
  _buf << '  <li>'; _buf << ( item[:name]] ).to_s; _buf << '</li>

--- a/test/test-main.rb
+++ b/test/test-main.rb
@@ -273,6 +273,19 @@ END
       errmsgs << <<'END'
 7: syntax error, unexpected $end, expecting keyword_end
 END
+    elsif ruby20?
+      errmsgs << <<'END'
+3: syntax error, unexpected ']', expecting ')'
+ _buf << '  <li>'; _buf << ( item[:name]] ).to_s; _buf << '</li>
+                                         ^
+-:4: syntax error, unexpected keyword_end, expecting ')'
+'; end 
+      ^
+-:7: syntax error, unexpected end-of-input, expecting ')'
+END
+      errmsgs << <<'END'
+7: syntax error, unexpected end-of-input, expecting keyword_end
+END
     elsif rubinius?
       errmsgs << <<'END'
 3: expecting ')'

--- a/test/test-main.rb
+++ b/test/test-main.rb
@@ -216,7 +216,7 @@ END
     begin
       ENV['PATH'] = bindir + File::PATH_SEPARATOR + ENV['PATH']
       ENV['_'] = 'erubis'
-      Tempfile.open(self.name.gsub(/[^\w]/,'_')) do |f|
+      Tempfile.open(self.method_name.gsub(/[^\w]/,'_')) do |f|
         f.write(INPUT)
         f.flush
         yield(f.path)
@@ -273,7 +273,7 @@ END
       errmsgs << <<'END'
 7: syntax error, unexpected $end, expecting keyword_end
 END
-    elsif ruby20? || ruby21?
+    elsif ruby20? || ruby21? || ruby22?
       errmsgs << <<'END'
 3: syntax error, unexpected ']', expecting ')'
  _buf << '  <li>'; _buf << ( item[:name]] ).to_s; _buf << '</li>

--- a/test/test-main.rb
+++ b/test/test-main.rb
@@ -273,7 +273,7 @@ END
       errmsgs << <<'END'
 7: syntax error, unexpected $end, expecting keyword_end
 END
-    elsif ruby20? || ruby21? || ruby22?
+    elsif ruby20? || ruby21? || ruby22? || ruby23?
       errmsgs << <<'END'
 3: syntax error, unexpected ']', expecting ')'
  _buf << '  <li>'; _buf << ( item[:name]] ).to_s; _buf << '</li>

--- a/test/test-users-guide.rb
+++ b/test/test-users-guide.rb
@@ -28,7 +28,7 @@ class KwarkUsersGuideTest < Test::Unit::TestCase
     s =~ /\A\$ (.*?)\n/
     command = $1
     expected = $'
-    if ruby19? || ruby20? || ruby21? || ruby22?
+    if ruby19? || ruby20? || ruby21? || ruby22? || ruby23?
       case @name
       when 'test_main_program1_result'
         expected.sub!('["eruby", "items", "x", "_buf"]', '[:_buf, :eruby, :items, :x]')

--- a/test/test-users-guide.rb
+++ b/test/test-users-guide.rb
@@ -28,7 +28,7 @@ class KwarkUsersGuideTest < Test::Unit::TestCase
     s =~ /\A\$ (.*?)\n/
     command = $1
     expected = $'
-    if ruby19? || ruby20? || ruby21?
+    if ruby19? || ruby20? || ruby21? || ruby22?
       case @name
       when 'test_main_program1_result'
         expected.sub!('["eruby", "items", "x", "_buf"]', '[:_buf, :eruby, :items, :x]')

--- a/test/test-users-guide.rb
+++ b/test/test-users-guide.rb
@@ -28,7 +28,7 @@ class KwarkUsersGuideTest < Test::Unit::TestCase
     s =~ /\A\$ (.*?)\n/
     command = $1
     expected = $'
-    if ruby19?
+    if ruby19? || ruby20?
       case @name
       when 'test_main_program1_result'
         expected.sub!('["eruby", "items", "x", "_buf"]', '[:_buf, :eruby, :items, :x]')

--- a/test/test-users-guide.rb
+++ b/test/test-users-guide.rb
@@ -28,7 +28,7 @@ class KwarkUsersGuideTest < Test::Unit::TestCase
     s =~ /\A\$ (.*?)\n/
     command = $1
     expected = $'
-    if ruby19? || ruby20?
+    if ruby19? || ruby20? || ruby21?
       case @name
       when 'test_main_program1_result'
         expected.sub!('["eruby", "items", "x", "_buf"]', '[:_buf, :eruby, :items, :x]')

--- a/test/testutil.rb
+++ b/test/testutil.rb
@@ -21,6 +21,10 @@ def ruby20?  # :nodoc:
   RUBY_VERSION =~ /\A2.0/
 end
 
+def ruby21?  # :nodoc:
+  RUBY_VERSION =~ /\A2.1/
+end
+
 def rubinius?  # :nodoc:
   defined?(RUBY_ENGINE) && RUBY_ENGINE == "rbx"
 end

--- a/test/testutil.rb
+++ b/test/testutil.rb
@@ -17,6 +17,10 @@ def ruby19?  # :nodoc:
   RUBY_VERSION =~ /\A1.9/
 end
 
+def ruby20?  # :nodoc:
+  RUBY_VERSION =~ /\A2.0/
+end
+
 def rubinius?  # :nodoc:
   defined?(RUBY_ENGINE) && RUBY_ENGINE == "rbx"
 end

--- a/test/testutil.rb
+++ b/test/testutil.rb
@@ -25,6 +25,10 @@ def ruby21?  # :nodoc:
   RUBY_VERSION =~ /\A2.1/
 end
 
+def ruby22?  # :nodoc:
+  RUBY_VERSION =~ /\A2.2/
+end
+
 def rubinius?  # :nodoc:
   defined?(RUBY_ENGINE) && RUBY_ENGINE == "rbx"
 end

--- a/test/testutil.rb
+++ b/test/testutil.rb
@@ -29,6 +29,10 @@ def ruby22?  # :nodoc:
   RUBY_VERSION =~ /\A2.2/
 end
 
+def ruby23?  # :nodoc:
+  RUBY_VERSION =~ /\A2.3/
+end
+
 def rubinius?  # :nodoc:
   defined?(RUBY_ENGINE) && RUBY_ENGINE == "rbx"
 end


### PR DESCRIPTION
Hi, kwatch (Kuwata-san).

This module's unit test was failed for Ruby 2.3.
ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-linux]

About Ruby 2.2. I could succeed the test by using below pull-request
https://github.com/kwatch/erubis/pull/5

So, I merged voxik's modification (support for Ruby 2.0, 2,1, 2,2) to my branch.
And I would like to do pull-request including his past modification this time.

Thank you!!

IN JAPANESE.

くわたさん
日本人の方のようですので、
日本語で捕捉させて戴きます。有賀と申します。
しばらく、このモジュールの更新がないようですが、
今、Fedora Projectで、このモジュールのRPMパッケージのメンテナンスをしておりまして、
その関係で、テストを最新のRubyで通す必要がありまして、対応しております。

できましたら、
この修正を取り込んで頂き、
将来のリリースバージョンに含めて頂けますと大変助かります。

ご質問等、ありましたら、お気軽にご連絡ください。（日本語でも！）
ありがとうございます。

有賀
