### PR TITLE
Don't ship test files in the gem artifact

### DIFF
--- a/erubis.gemspec
+++ b/erubis.gemspec
@@ -36,17 +36,11 @@ spec = Gem::Specification.new do |s|
   files = []
   files += Dir.glob('lib/**/*')
   files += Dir.glob('bin/*')
-  files += Dir.glob('examples/**/*')
-  files += Dir.glob('test/**/*')
-  files += Dir.glob('doc/**/*')
-  files += %w[README.txt CHANGES.txt MIT-LICENSE setup.rb]
+  files += %w[README.txt MIT-LICENSE setup.rb]
   files += Dir.glob('contrib/**/*')
-  files += Dir.glob('benchmark/**/*')
-  files += Dir.glob('doc-api/**/*')
   s.files       = files
   s.executables = ['erubis']
   s.bindir      = 'bin'
-  s.test_file   = 'test/test.rb'
   #s.add_dependency('abstract', ['>= 1.0.0'])
 end
 


### PR DESCRIPTION
There's no need to ship testing artifacts in the gem artifact. It only
increases the size of the installed gem on user systems.

Signed-off-by: Tim Smith <tsmith@chef.io>