### PR TITLE
Fix XSS when escaping single-quotes 

### DIFF
--- a/lib/erubis/helpers/rails_helper.rb
+++ b/lib/erubis/helpers/rails_helper.rb
@@ -340,7 +340,7 @@ else                                           ###  Rails 1.X
   module ERB::Util  # :nodoc:
     ESCAPE_TABLE = { '&'=>'&amp;', '<'=>'&lt;', '>'=>'&gt;', '"'=>'&quot;', "'"=>'&#039;', }
     def h(value)
-      value.to_s.gsub(/[&<>"]/) {|s| ESCAPE_TABLE[s] }
+      value.to_s.gsub(/[&<>"']/) {|s| ESCAPE_TABLE[s] }
     end
     module_function :h
   end


### PR DESCRIPTION
"Affected versions of the package are vulnerable to Cross-site Scripting (XSS). Single quotes were not properly escaped in the helper.rb and helpers/rails_helper.rb files."
Fixed the escaping function by adding the missing character in the validation regex.