### PR TITLE
Add support for Ruby 3.0

### DIFF
--- a/lib/erubis/engine.rb
+++ b/lib/erubis/engine.rb
@@ -60,7 +60,9 @@ module Erubis
         File.rename(tmpname, cachename)
         File.utime(timestamp, timestamp, cachename)
       end
-      engine.src.untaint   # ok?
+      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7')
+        engine.src.untaint   # ok?
+      end
       return engine
     end
 

--- a/test/test-engines.rb
+++ b/test/test-engines.rb
@@ -71,7 +71,8 @@ __END__
 - name:  ruby2_options
   lang:  ruby
   class: Eruby
-  options: { :bufvar: '@_out_buf' }
+  options:
+    :bufvar: '@_out_buf'
   input: |
       <table>
         <% for item in @items %>
@@ -137,7 +138,9 @@ __END__
 - name:  c1
   lang:  c
   class: Ec
-  options: { :filename: foo.html, :indent: '  ' }
+  options:
+    :filename: foo.html
+    :indent: '  '
   input: |4
       <table>
        <tbody>
@@ -167,7 +170,9 @@ __END__
 - name:  cpp1
   lang:  cpp
   class: Ecpp
-  options: { :filename: foo.html, :indent: '  ' }
+  options:
+    :filename: foo.html
+    :indent: '  '
   input: |4
       <table>
        <tbody>
@@ -197,7 +202,10 @@ __END__
 - name:  java1
   lang:  java
   class: Ejava
-  options: { :buf: _buf, :bufclass: StringBuilder, :indent: '    ' }
+  options:
+    :buf: _buf,
+    :bufclass: StringBuilder
+    :indent: '    '
   input: |
       <table>
        <tbody>
@@ -220,19 +228,19 @@ __END__
   expected: |4
           StringBuilder _buf = new StringBuilder(); _buf.append("<table>\n"
                     + " <tbody>\n");
-           
+      
           int i = 0;
           for (Iterator it = list.iterator(); it.hasNext(); ) {
               String s = (String)it.next();
               i++;
-             
+      
           _buf.append("  <tr class=\""); _buf.append(i%2==0 ? "even" : "odd"); _buf.append("\">\n"
                     + "   <td>"); _buf.append(i); _buf.append("</td>\n"
                     + "   <td>"); _buf.append(escape(s)); _buf.append("</td>\n"
                     + "  </tr>\n");
-           
+      
           }
-          
+      
           _buf.append(" <tbody>\n"
                     + "</table>\n");
            System.err.println("*** debug: i="+(i)); _buf.append("\n");
@@ -242,7 +250,7 @@ __END__
   lang:  scheme
   class: Escheme
   options:
-  input: &scheme1_input|
+  input: &scheme1_input |
       <% (let ((i 0)) %>
       <table>
        <tbody>
@@ -290,7 +298,8 @@ __END__
 - name:  scheme2
   lang:  scheme
   class: Escheme
-  options: { :func: 'display' }
+  options:
+    :func: 'display'
   input: *scheme1_input
   expected: |4
        (let ((i 0)) 
@@ -401,7 +410,8 @@ __END__
 - name:  javascript2
   lang:  javascript
   class: Ejavascript
-  options: { :docwrite: false }
+  options:
+    :docwrite: false
   input: *javascript_input
   expected: |4
       var _buf = [];

--- a/test/test-enhancers.rb
+++ b/test/test-enhancers.rb
@@ -106,13 +106,13 @@ __END__
 ##
 - name:  basic1
   class: Eruby
-  input: &basic1_input|
+  input: &basic1_input |
       <ul>
        <% for item in list %>
         <li><%= item %></li>
        <% end %>
       </ul>
-  src: &basic1_src|
+  src: &basic1_src |
       _buf = ''; _buf << '<ul>
       ';  for item in list 
        _buf << '  <li>'; _buf << ( item ).to_s; _buf << '</li>
@@ -120,7 +120,7 @@ __END__
        _buf << '</ul>
       ';
       _buf.to_s
-  output: &basic1_output|
+  output: &basic1_output |
       <ul>
         <li><aaa></li>
         <li>b&b</li>
@@ -193,7 +193,7 @@ __END__
 ##
 - name:  printenabled1
   class: PrintEnabledEruby
-  input: &printenabled1_input|
+  input: &printenabled1_input |
       <ul>
        <% for item in list %>
         <li><% print item %></li>
@@ -425,7 +425,8 @@ __END__
 ##
 - name:  bipattern2
   class: BiPatternEruby
-  options:  { :bipattern: '\$\{ \}' }
+  options:
+    :bipattern: '\$\{ \}'
   input: |
       <% for item in list %>
         <%=item%> % <%==item%>
@@ -500,7 +501,8 @@ __END__
 ##
 - name:  prefixedline1
   class: PrefixedLineEruby
-  options: { :prefixchar: '!' }
+  options:
+   :prefixchar: '!'
   input: |
       <table>
         ! for item in list

--- a/test/test-erubis.rb
+++ b/test/test-erubis.rb
@@ -220,13 +220,13 @@ y = 20
 
 __END__
 - name:  basic1
-  input: &basic1_input|
+  input: &basic1_input |
       <ul>
        <% for item in list %>
         <li><%= item %></li>
        <% end %>
       </ul>
-  src: &basic1_src|
+  src: &basic1_src |
       _buf = ''; _buf << '<ul>
       ';  for item in list 
        _buf << '  <li>'; _buf << ( item ).to_s; _buf << '</li>
@@ -234,7 +234,7 @@ __END__
        _buf << '</ul>
       ';
       _buf.to_s
-  output: &basic1_output|
+  output: &basic1_output |
       <ul>
         <li><aaa></li>
         <li>b&b</li>
@@ -344,7 +344,7 @@ __END__
 - name:  quotation1
   desc:  single quotation and backslash
   class: Eruby
-  input: &quotation1_input|
+  input: &quotation1_input |
       a = "'"
       b = "\""
       c = '\''
@@ -451,7 +451,9 @@ __END__
 ##
 - name:  bodyonly1
   testopt:  skip_output
-  options: { :preamble: no, :postamble: no }
+  options:
+   :preamble: no
+   :postamble: no
   input: *basic1_input
   src: |4
        _buf << '<ul>
@@ -496,7 +498,7 @@ __END__
 ##
 - name:  nomatch1
   desc:  bug
-  input: &nomatch1|
+  input: &nomatch1 |
       <ul>
         <li>foo</li>
       </ul>
@@ -510,7 +512,8 @@ __END__
 
 ##
 - name:  escape1
-  options: { :escape: true }
+  options:
+   :escape: true
   input: |
       <% str = '<>&"' %>
       <%= str %>
@@ -570,7 +573,7 @@ __END__
 ##
 - name:  optimized1
   class: OptimizedEruby
-  input: &optimized1_input|
+  input: &optimized1_input |
       <table>
        <% for item in list %>
         <tr>
@@ -677,7 +680,7 @@ __END__
 - name:  optimized4
   desc:  single quotation and backslash
   class: OptimizedEruby
-  input: &optimized4_input|
+  input: &optimized4_input |
       a = "'"
       b = "\""
       c = '\''
@@ -751,14 +754,14 @@ __END__
 - name:  pi1
   class:  PI::Eruby
   testopt:  evaluate
-  input: &input_pi1|
+  input: &input_pi1 |
       <ul>
        <?rb for item in @list ?>
         <li>@{item}@ / @!{item}@</li>
         <li><%= item %> / <%== item %></li>
        <?rb end ?>
       </ul>
-  src: &src_pi1|
+  src: &src_pi1 |
       _buf = ''; _buf << '<ul>
       ';  for item in @list 
        _buf << '  <li>'; _buf << Erubis::XmlHelper.escape_xml(item); _buf << ' / '; _buf << (item).to_s; _buf << '</li>
@@ -767,7 +770,7 @@ __END__
        _buf << '</ul>
       ';
       _buf.to_s
-  output: &output_pi1|
+  output: &output_pi1 |
       <ul>
         <li>&lt;aaa&gt; / <aaa></li>
         <li><aaa> / &lt;aaa&gt;</li>
@@ -780,7 +783,8 @@ __END__
 ##
 - name:  pi2
   class:  PI::Eruby
-  options: { :escape: false }
+  options:
+   :escape: false
   testopt:  evaluate
   input: *input_pi1
   src: |
@@ -805,7 +809,9 @@ __END__
 ##
 - name:  pi3
   class:  PI::Eruby
-  options: { :pi: hoge, :embchar: '$' }
+  options:
+   :pi: hoge
+   :embchar: '$'
   testopt:  evaluate
   input: |
       <ul>

--- a/test/test-main.rb
+++ b/test/test-main.rb
@@ -329,7 +329,7 @@ END
       errmsgs << <<'END'
 7: syntax error, unexpected end-of-input, expecting end
 END
-    elsif ruby27?
+    elsif ruby27? || ruby30?
       errmsgs << <<'END'
 3: syntax error, unexpected ']', expecting ')'
 ...  <li>'; _buf << ( item[:name]] ).to_s; _buf << '</li>

--- a/test/test-main.rb
+++ b/test/test-main.rb
@@ -316,6 +316,19 @@ END
 _buf.to_s
          ^
 END
+    elsif ruby26?
+      errmsgs << <<'END'
+3: syntax error, unexpected ']', expecting ')'
+...  <li>'; _buf << ( item[:name]] ).to_s; _buf << '</li>
+...                              ^
+-:4: syntax error, unexpected end, expecting ')'
+'; end 
+   ^~~
+-:7: syntax error, unexpected end-of-input, expecting ')'
+END
+      errmsgs << <<'END'
+7: syntax error, unexpected end-of-input, expecting end
+END
     elsif rubinius?
       errmsgs << <<'END'
 3: expecting ')'

--- a/test/test-main.rb
+++ b/test/test-main.rb
@@ -273,7 +273,7 @@ END
       errmsgs << <<'END'
 7: syntax error, unexpected $end, expecting keyword_end
 END
-    elsif ruby20?
+    elsif ruby20? || ruby21?
       errmsgs << <<'END'
 3: syntax error, unexpected ']', expecting ')'
  _buf << '  <li>'; _buf << ( item[:name]] ).to_s; _buf << '</li>

--- a/test/test-main.rb
+++ b/test/test-main.rb
@@ -273,6 +273,19 @@ END
       errmsgs << <<'END'
 7: syntax error, unexpected $end, expecting keyword_end
 END
+    elsif ruby20?
+      errmsgs << <<'END'
+3: syntax error, unexpected ']', expecting ')'
+ _buf << '  <li>'; _buf << ( item[:name]] ).to_s; _buf << '</li>
+                                         ^
+-:4: syntax error, unexpected keyword_end, expecting ')'
+'; end 
+      ^
+-:7: syntax error, unexpected end-of-input, expecting ')'
+END
+      errmsgs << <<'END'
+7: syntax error, unexpected end-of-input, expecting keyword_end
+END
     elsif rubinius?
       errmsgs << <<'END'
 3: expecting ')'

--- a/test/test-main.rb
+++ b/test/test-main.rb
@@ -329,6 +329,19 @@ END
       errmsgs << <<'END'
 7: syntax error, unexpected end-of-input, expecting end
 END
+    elsif ruby27?
+      errmsgs << <<'END'
+3: syntax error, unexpected ']', expecting ')'
+...  <li>'; _buf << ( item[:name]] ).to_s; _buf << '</li>
+...                              ^
+-:4: syntax error, unexpected `end', expecting ')'
+'; end 
+   ^~~
+-:7: syntax error, unexpected end-of-input, expecting ')'
+END
+      errmsgs << <<'END'
+7: syntax error, unexpected end-of-input, expecting `end'
+END
     elsif rubinius?
       errmsgs << <<'END'
 3: expecting ')'

--- a/test/test-main.rb
+++ b/test/test-main.rb
@@ -216,7 +216,7 @@ END
     begin
       ENV['PATH'] = bindir + File::PATH_SEPARATOR + ENV['PATH']
       ENV['_'] = 'erubis'
-      Tempfile.open(self.name.gsub(/[^\w]/,'_')) do |f|
+      Tempfile.open(self.method_name.gsub(/[^\w]/,'_')) do |f|
         f.write(INPUT)
         f.flush
         yield(f.path)
@@ -273,7 +273,7 @@ END
       errmsgs << <<'END'
 7: syntax error, unexpected $end, expecting keyword_end
 END
-    elsif ruby20? || ruby21?
+    elsif ruby20? || ruby21? || ruby22?
       errmsgs << <<'END'
 3: syntax error, unexpected ']', expecting ')'
  _buf << '  <li>'; _buf << ( item[:name]] ).to_s; _buf << '</li>

--- a/test/test-main.rb
+++ b/test/test-main.rb
@@ -286,6 +286,19 @@ END
       errmsgs << <<'END'
 7: syntax error, unexpected end-of-input, expecting keyword_end
 END
+    elsif ruby24?
+      errmsgs << <<'END'
+3: syntax error, unexpected ']', expecting ')'
+ <li>'; _buf << ( item[:name]] ).to_s; _buf << '</li>
+                              ^
+-:4: syntax error, unexpected keyword_end, expecting ')'
+'; end 
+      ^
+-:7: syntax error, unexpected end-of-input, expecting ')'
+END
+      errmsgs << <<'END'
+7: syntax error, unexpected end-of-input, expecting keyword_end
+END
     elsif rubinius?
       errmsgs << <<'END'
 3: expecting ')'

--- a/test/test-main.rb
+++ b/test/test-main.rb
@@ -273,7 +273,7 @@ END
       errmsgs << <<'END'
 7: syntax error, unexpected $end, expecting keyword_end
 END
-    elsif ruby20? || ruby21? || ruby22?
+    elsif ruby20? || ruby21? || ruby22? || ruby23?
       errmsgs << <<'END'
 3: syntax error, unexpected ']', expecting ')'
  _buf << '  <li>'; _buf << ( item[:name]] ).to_s; _buf << '</li>

--- a/test/test-main.rb
+++ b/test/test-main.rb
@@ -299,6 +299,23 @@ END
       errmsgs << <<'END'
 7: syntax error, unexpected end-of-input, expecting keyword_end
 END
+    elsif ruby25?
+      errmsgs << <<'END'
+3: syntax error, unexpected ']', expecting ')'
+...  <li>'; _buf << ( item[:name]] ).to_s; _buf << '</li>
+...                              ^
+-:4: syntax error, unexpected keyword_end, expecting ')'
+'; end 
+   ^~~
+-:7: syntax error, unexpected end-of-input, expecting ')'
+_buf.to_s
+         ^
+END
+      errmsgs << <<'END'
+7: syntax error, unexpected end-of-input, expecting keyword_end
+_buf.to_s
+         ^
+END
     elsif rubinius?
       errmsgs << <<'END'
 3: expecting ')'

--- a/test/test-users-guide.rb
+++ b/test/test-users-guide.rb
@@ -28,7 +28,7 @@ class KwarkUsersGuideTest < Test::Unit::TestCase
     s =~ /\A\$ (.*?)\n/
     command = $1
     expected = $'
-    if ruby19? || ruby20? || ruby21? || ruby22? || ruby23? || ruby24?
+    if ruby19? || ruby20? || ruby21? || ruby22? || ruby23? || ruby24? || ruby25?
       case @name
       when 'test_main_program1_result'
         expected.sub!('["eruby", "items", "x", "_buf"]', '[:_buf, :eruby, :items, :x]')

--- a/test/test-users-guide.rb
+++ b/test/test-users-guide.rb
@@ -28,7 +28,7 @@ class KwarkUsersGuideTest < Test::Unit::TestCase
     s =~ /\A\$ (.*?)\n/
     command = $1
     expected = $'
-    if ruby19? || ruby20? || ruby21? || ruby22? || ruby23? || ruby24? || ruby25?
+    if ruby19? || ruby20? || ruby21? || ruby22? || ruby23? || ruby24? || ruby25? || ruby26?
       case @name
       when 'test_main_program1_result'
         expected.sub!('["eruby", "items", "x", "_buf"]', '[:_buf, :eruby, :items, :x]')

--- a/test/test-users-guide.rb
+++ b/test/test-users-guide.rb
@@ -28,7 +28,7 @@ class KwarkUsersGuideTest < Test::Unit::TestCase
     s =~ /\A\$ (.*?)\n/
     command = $1
     expected = $'
-    if ruby19? || ruby20? || ruby21? || ruby22?
+    if ruby19? || ruby20? || ruby21? || ruby22? || ruby23?
       case @name
       when 'test_main_program1_result'
         expected.sub!('["eruby", "items", "x", "_buf"]', '[:_buf, :eruby, :items, :x]')

--- a/test/test-users-guide.rb
+++ b/test/test-users-guide.rb
@@ -28,7 +28,7 @@ class KwarkUsersGuideTest < Test::Unit::TestCase
     s =~ /\A\$ (.*?)\n/
     command = $1
     expected = $'
-    if ruby19? || ruby20? || ruby21?
+    if ruby19? || ruby20? || ruby21? || ruby22?
       case @name
       when 'test_main_program1_result'
         expected.sub!('["eruby", "items", "x", "_buf"]', '[:_buf, :eruby, :items, :x]')

--- a/test/test-users-guide.rb
+++ b/test/test-users-guide.rb
@@ -28,7 +28,7 @@ class KwarkUsersGuideTest < Test::Unit::TestCase
     s =~ /\A\$ (.*?)\n/
     command = $1
     expected = $'
-    if ruby19? || ruby20? || ruby21? || ruby22? || ruby23?
+    if ruby19? || ruby20? || ruby21? || ruby22? || ruby23? || ruby24?
       case @name
       when 'test_main_program1_result'
         expected.sub!('["eruby", "items", "x", "_buf"]', '[:_buf, :eruby, :items, :x]')

--- a/test/test-users-guide.rb
+++ b/test/test-users-guide.rb
@@ -28,7 +28,7 @@ class KwarkUsersGuideTest < Test::Unit::TestCase
     s =~ /\A\$ (.*?)\n/
     command = $1
     expected = $'
-    if ruby19? || ruby20? || ruby21? || ruby22? || ruby23? || ruby24? || ruby25? || ruby26?
+    if ruby19? || ruby20? || ruby21? || ruby22? || ruby23? || ruby24? || ruby25? || ruby26? || ruby27?
       case @name
       when 'test_main_program1_result'
         expected.sub!('["eruby", "items", "x", "_buf"]', '[:_buf, :eruby, :items, :x]')

--- a/test/test-users-guide.rb
+++ b/test/test-users-guide.rb
@@ -28,7 +28,7 @@ class KwarkUsersGuideTest < Test::Unit::TestCase
     s =~ /\A\$ (.*?)\n/
     command = $1
     expected = $'
-    if ruby19? || ruby20? || ruby21? || ruby22? || ruby23? || ruby24? || ruby25? || ruby26? || ruby27?
+    if ruby19? || ruby20? || ruby21? || ruby22? || ruby23? || ruby24? || ruby25? || ruby26? || ruby27? || ruby30?
       case @name
       when 'test_main_program1_result'
         expected.sub!('["eruby", "items", "x", "_buf"]', '[:_buf, :eruby, :items, :x]')

--- a/test/test-users-guide.rb
+++ b/test/test-users-guide.rb
@@ -28,7 +28,7 @@ class KwarkUsersGuideTest < Test::Unit::TestCase
     s =~ /\A\$ (.*?)\n/
     command = $1
     expected = $'
-    if ruby19?
+    if ruby19? || ruby20?
       case @name
       when 'test_main_program1_result'
         expected.sub!('["eruby", "items", "x", "_buf"]', '[:_buf, :eruby, :items, :x]')

--- a/test/test-users-guide.rb
+++ b/test/test-users-guide.rb
@@ -28,7 +28,7 @@ class KwarkUsersGuideTest < Test::Unit::TestCase
     s =~ /\A\$ (.*?)\n/
     command = $1
     expected = $'
-    if ruby19? || ruby20?
+    if ruby19? || ruby20? || ruby21?
       case @name
       when 'test_main_program1_result'
         expected.sub!('["eruby", "items", "x", "_buf"]', '[:_buf, :eruby, :items, :x]')

--- a/test/testutil.rb
+++ b/test/testutil.rb
@@ -37,6 +37,10 @@ def ruby24?  # :nodoc:
   RUBY_VERSION =~ /\A2.4/
 end
 
+def ruby25?  # :nodoc:
+  RUBY_VERSION =~ /\A2.5/
+end
+
 def rubinius?  # :nodoc:
   defined?(RUBY_ENGINE) && RUBY_ENGINE == "rbx"
 end
@@ -57,7 +61,7 @@ class Test::Unit::TestCase
     s = _untabify(s) unless options[:tabify] == false
     # load yaml document
     testdata_list = []
-    YAML.load_documents(s) do |ydoc|
+    YAML.load_stream(s) do |ydoc|
       if ydoc.is_a?(Hash)
         testdata_list << ydoc
       elsif ydoc.is_a?(Array)

--- a/test/testutil.rb
+++ b/test/testutil.rb
@@ -45,6 +45,10 @@ def ruby26?  # :nodoc:
   RUBY_VERSION =~ /\A2.6/
 end
 
+def ruby27?  # :nodoc:
+  RUBY_VERSION =~ /\A2.7/
+end
+
 def rubinius?  # :nodoc:
   defined?(RUBY_ENGINE) && RUBY_ENGINE == "rbx"
 end

--- a/test/testutil.rb
+++ b/test/testutil.rb
@@ -21,6 +21,10 @@ def ruby20?  # :nodoc:
   RUBY_VERSION =~ /\A2.0/
 end
 
+def ruby21?  # :nodoc:
+  RUBY_VERSION =~ /\A2.1/
+end
+
 def rubinius?  # :nodoc:
   defined?(RUBY_ENGINE) && RUBY_ENGINE == "rbx"
 end

--- a/test/testutil.rb
+++ b/test/testutil.rb
@@ -17,6 +17,10 @@ def ruby19?  # :nodoc:
   RUBY_VERSION =~ /\A1.9/
 end
 
+def ruby20?  # :nodoc:
+  RUBY_VERSION =~ /\A2.0/
+end
+
 def rubinius?  # :nodoc:
   defined?(RUBY_ENGINE) && RUBY_ENGINE == "rbx"
 end

--- a/test/testutil.rb
+++ b/test/testutil.rb
@@ -25,6 +25,10 @@ def ruby21?  # :nodoc:
   RUBY_VERSION =~ /\A2.1/
 end
 
+def ruby22?  # :nodoc:
+  RUBY_VERSION =~ /\A2.2/
+end
+
 def rubinius?  # :nodoc:
   defined?(RUBY_ENGINE) && RUBY_ENGINE == "rbx"
 end

--- a/test/testutil.rb
+++ b/test/testutil.rb
@@ -33,6 +33,10 @@ def ruby23?  # :nodoc:
   RUBY_VERSION =~ /\A2.3/
 end
 
+def ruby24?  # :nodoc:
+  RUBY_VERSION =~ /\A2.4/
+end
+
 def rubinius?  # :nodoc:
   defined?(RUBY_ENGINE) && RUBY_ENGINE == "rbx"
 end

--- a/test/testutil.rb
+++ b/test/testutil.rb
@@ -29,6 +29,10 @@ def ruby22?  # :nodoc:
   RUBY_VERSION =~ /\A2.2/
 end
 
+def ruby23?  # :nodoc:
+  RUBY_VERSION =~ /\A2.3/
+end
+
 def rubinius?  # :nodoc:
   defined?(RUBY_ENGINE) && RUBY_ENGINE == "rbx"
 end

--- a/test/testutil.rb
+++ b/test/testutil.rb
@@ -49,6 +49,10 @@ def ruby27?  # :nodoc:
   RUBY_VERSION =~ /\A2.7/
 end
 
+def ruby30?  # :nodoc:
+  RUBY_VERSION =~ /\A3.0/
+end
+
 def rubinius?  # :nodoc:
   defined?(RUBY_ENGINE) && RUBY_ENGINE == "rbx"
 end

--- a/test/testutil.rb
+++ b/test/testutil.rb
@@ -41,6 +41,10 @@ def ruby25?  # :nodoc:
   RUBY_VERSION =~ /\A2.5/
 end
 
+def ruby26?  # :nodoc:
+  RUBY_VERSION =~ /\A2.6/
+end
+
 def rubinius?  # :nodoc:
   defined?(RUBY_ENGINE) && RUBY_ENGINE == "rbx"
 end


### PR DESCRIPTION
This change fixes tests failed with Ruby 3.0 and a warning about deprecated `untaint` method.

This is cumulative change based on #20.